### PR TITLE
fix shadowlings

### DIFF
--- a/Content.Server/_EE/Shadowling/Systems/LightDetectionSystem.cs
+++ b/Content.Server/_EE/Shadowling/Systems/LightDetectionSystem.cs
@@ -63,7 +63,7 @@ public sealed class LightDetectionSystem : EntitySystem
         var query = EntityQueryEnumerator<PointLightComponent>();
         while (query.MoveNext(out var point, out var pointLight))
         {
-            if (!pointLight.Enabled)
+            if (!pointLight.Enabled || pointLight.Energy <= 0.001f) // Orehum fix shadowling killed by unpowered lights :(
                 continue;
 
             var lightPos = _transformSystem.GetWorldPosition(point);


### PR DESCRIPTION
Shadowlings больше не получают урон от обесточенных ламп.
Однако, если он был плазмаменом, он все еще помирает от токсинов :(

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: badryuner
- fix: Fixed shadowlings
