### PR TITLE
remove barotrauma for ipc

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -135,10 +135,10 @@
   - type: Damageable
     damageContainer: SiliconUnshielded
     damageModifierSet: IPC
-  - type: Barotrauma
-    damage:
-      types:
-        Heat: 0.55 #per second, scales with pressure and other constants. Uniquely Heat instead of blunt, to simulate mechanical overheating in vacuum. IPCs are normally air cooled.
+  #- type: Barotrauma # Orehum IPC не получает больше урона от давления
+  #  damage:
+  #    types:
+  #      Heat: 0.55 #per second, scales with pressure and other constants. Uniquely Heat instead of blunt, to simulate mechanical overheating in vacuum. IPCs are normally air cooled.
   - type: Bloodstream
     bloodlossDamage:
       types:


### PR DESCRIPTION

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: IPC больше не получает урон от давления
