### PR TITLE
fix width/height sliders update

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1409,14 +1409,14 @@ namespace Content.Client.Lobby.UI
         private void SetProfileHeight(float height)
         {
             Profile = Profile?.WithHeight(height);
-            SetDirty();
+            IsDirty = true;
             ReloadProfilePreview();
         }
 
         private void SetProfileWidth(float width)
         {
             Profile = Profile?.WithWidth(width);
-            SetDirty();
+            IsDirty = true;
             ReloadProfilePreview();
         }
 


### PR DESCRIPTION

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Исправил невозможность сохранить персонажа, когда меняешь рост или вес, т.к не загоралась кнопка сохранить.
