### PR TITLE
Убрал ScottishAccent для кобольдов

### DIFF
--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1371,9 +1371,9 @@
         - type: LiquorLifeline
         - type: LightweightDrunk
           boozeStrengthMultiplier: 0.5
-    - !type:TraitAddComponent
-      components:
-        - type: ScottishAccent
+    #- !type:TraitAddComponent
+    #  components:
+    #    - type: ScottishAccent
     - !type:TraitAddArmor
       damageModifierSets:
         - ExtremePoisonResistance


### PR DESCRIPTION

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: BadRyuner
- remove: Убрал ScottishAccent для кобольдов
