### PR TITLE
Ребаланс модификаторов очков для компонентов аномалий

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Vessel.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Vessel.cs
@@ -75,7 +75,7 @@ public sealed partial class AnomalySystem
         var pointRating = args.PartRatings[component.MachinePartPointMultiplier];
         var radRating = args.PartRatings[component.MachinePartPointMultiplier];
 
-        component.PointMultiplier = component.BasePointMultiplier * (component.UpgradePointMultiplier * pointRating);
+        component.PointMultiplier = (pointRating / 2f) + 0.5f;
 
         if (TryComp<RadiationSourceComponent>(uid, out var radiation))
             radiation.Intensity = component.BaseRadiation * radRating;


### PR DESCRIPTION
Изменяет баланс модификаторов очков для компонентов аномалий, чтобы сделать исследования и разработки (R&D) менее утомительными.
В старой системе для компонентов 1-го уровня был модификатор -50%, что затрудняло исследования на раннем этапе.
Новая система изменяет модификаторы следующим образом:
Уровень 1: 1x
Уровень 2: 1.5x (+50%)
Уровень 3: 2.0x (+100%)
